### PR TITLE
Output frame from message

### DIFF
--- a/ar_track_alvar/include/ar_track_alvar/Camera.h
+++ b/ar_track_alvar/include/ar_track_alvar/Camera.h
@@ -89,6 +89,7 @@ public:
 	int calib_y_res;
 	int x_res;
 	int y_res;
+	std::string frame;
 	bool getCamInfo_;
 
 protected:

--- a/ar_track_alvar/nodes/IndividualMarkers.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkers.cpp
@@ -272,7 +272,7 @@ void GetMarkerPoses(IplImage *image, ARCloud &cloud) {
 
   //Detect and track the markers
   if (marker_detector.Detect(image, cam, true, false, max_new_marker_error,
-                 max_track_error, CVSEQ, true))
+                             max_track_error, CVSEQ, true))
   {
     ROS_DEBUG_STREAM("--------------------------");
     for (size_t i=0; i<marker_detector.markers->size(); i++)
@@ -322,8 +322,10 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
   sensor_msgs::ImagePtr image_msg(new sensor_msgs::Image);
 
   // If desired, use the frame in the message's header.
-  if (output_frame_from_msg)
+  if (output_frame_from_msg) {
     output_frame = msg->header.frame_id;
+    output_frame_from_msg = false;
+  }
 
   //If we've already gotten the cam info, then go ahead
   if(cam->getCamInfo_){

--- a/ar_track_alvar/nodes/IndividualMarkers.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkers.cpp
@@ -202,17 +202,17 @@ int PlaneFitPoseImprovement(int id, const ARCloud &corners_3D, ARCloud::Ptr sele
   int i1,i2;
   if(isnan(corners_3D[0].x) || isnan(corners_3D[0].y) || isnan(corners_3D[0].z) ||
      isnan(corners_3D[3].x) || isnan(corners_3D[3].y) || isnan(corners_3D[3].z))
+  {
+    if(isnan(corners_3D[1].x) || isnan(corners_3D[1].y) || isnan(corners_3D[1].z) ||
+       isnan(corners_3D[2].x) || isnan(corners_3D[2].y) || isnan(corners_3D[2].z))
     {
-      if(isnan(corners_3D[1].x) || isnan(corners_3D[1].y) || isnan(corners_3D[1].z) ||
-	 isnan(corners_3D[2].x) || isnan(corners_3D[2].y) || isnan(corners_3D[2].z))
-	{
-	  return -1;
-	}
-      else{
-	i1 = 1;
-	i2 = 2;
-      }
+      return -1;
     }
+    else{
+      i1 = 1;
+      i2 = 2;
+    }
+  }
   else{
     i1 = 0;
     i2 = 3;
@@ -222,17 +222,17 @@ int PlaneFitPoseImprovement(int id, const ARCloud &corners_3D, ARCloud::Ptr sele
   int i3,i4;
   if(isnan(corners_3D[0].x) || isnan(corners_3D[0].y) || isnan(corners_3D[0].z) ||
      isnan(corners_3D[1].x) || isnan(corners_3D[1].y) || isnan(corners_3D[1].z))
+  {
+    if(isnan(corners_3D[3].x) || isnan(corners_3D[3].y) || isnan(corners_3D[3].z) ||
+     isnan(corners_3D[2].x) || isnan(corners_3D[2].y) || isnan(corners_3D[2].z))
     {
-      if(isnan(corners_3D[3].x) || isnan(corners_3D[3].y) || isnan(corners_3D[3].z) ||
-	 isnan(corners_3D[2].x) || isnan(corners_3D[2].y) || isnan(corners_3D[2].z))
-	{
-	  return -1;
-	}
-      else{
-	i3 = 2;
-	i4 = 3;
-      }
+      return -1;
     }
+    else{
+      i3 = 2;
+      i4 = 3;
+    }
+  }
   else{
     i3 = 1;
     i4 = 0;
@@ -272,47 +272,47 @@ void GetMarkerPoses(IplImage *image, ARCloud &cloud) {
 
   //Detect and track the markers
   if (marker_detector.Detect(image, cam, true, false, max_new_marker_error,
-			     max_track_error, CVSEQ, true))
+                 max_track_error, CVSEQ, true))
+  {
+    ROS_DEBUG_STREAM("--------------------------");
+    for (size_t i=0; i<marker_detector.markers->size(); i++)
     {
-      ROS_DEBUG_STREAM("--------------------------");
-      for (size_t i=0; i<marker_detector.markers->size(); i++)
-     	{
-	  vector<cv::Point, Eigen::aligned_allocator<cv::Point> > pixels;
-	  Marker *m = &((*marker_detector.markers)[i]);
-	  int id = m->GetId();
-	  ROS_DEBUG_STREAM("******* ID: " << id);
+      vector<cv::Point, Eigen::aligned_allocator<cv::Point> > pixels;
+      Marker *m = &((*marker_detector.markers)[i]);
+      int id = m->GetId();
+      ROS_DEBUG_STREAM("******* ID: " << id);
 
-	  int resol = m->GetRes();
-	  int ori = m->ros_orientation;
+      int resol = m->GetRes();
+      int ori = m->ros_orientation;
 
-	  PointDouble pt1, pt2, pt3, pt4;
-	  pt4 = m->ros_marker_points_img[0];
-	  pt3 = m->ros_marker_points_img[resol-1];
-	  pt1 = m->ros_marker_points_img[(resol*resol)-resol];
-	  pt2 = m->ros_marker_points_img[(resol*resol)-1];
+      PointDouble pt1, pt2, pt3, pt4;
+      pt4 = m->ros_marker_points_img[0];
+      pt3 = m->ros_marker_points_img[resol-1];
+      pt1 = m->ros_marker_points_img[(resol*resol)-resol];
+      pt2 = m->ros_marker_points_img[(resol*resol)-1];
 
-	  m->ros_corners_3D[0] = cloud(pt1.x, pt1.y);
-	  m->ros_corners_3D[1] = cloud(pt2.x, pt2.y);
-	  m->ros_corners_3D[2] = cloud(pt3.x, pt3.y);
-	  m->ros_corners_3D[3] = cloud(pt4.x, pt4.y);
+      m->ros_corners_3D[0] = cloud(pt1.x, pt1.y);
+      m->ros_corners_3D[1] = cloud(pt2.x, pt2.y);
+      m->ros_corners_3D[2] = cloud(pt3.x, pt3.y);
+      m->ros_corners_3D[3] = cloud(pt4.x, pt4.y);
 
-	  if(ori >= 0 && ori < 4){
-	    if(ori != 0){
-	      std::rotate(m->ros_corners_3D.begin(), m->ros_corners_3D.begin() + ori, m->ros_corners_3D.end());
-	    }
-	  }
-	  else
-	    ROS_ERROR("FindMarkerBundles: Bad Orientation: %i for ID: %i", ori, id);
+      if(ori >= 0 && ori < 4){
+        if(ori != 0){
+          std::rotate(m->ros_corners_3D.begin(), m->ros_corners_3D.begin() + ori, m->ros_corners_3D.end());
+        }
+      }
+      else
+        ROS_ERROR("FindMarkerBundles: Bad Orientation: %i for ID: %i", ori, id);
 
-	  //Get the 3D marker points
-	  BOOST_FOREACH (const PointDouble& p, m->ros_marker_points_img)
-	    pixels.push_back(cv::Point(p.x, p.y));
-	  ARCloud::Ptr selected_points = ata::filterCloud(cloud, pixels);
+      //Get the 3D marker points
+      BOOST_FOREACH (const PointDouble& p, m->ros_marker_points_img)
+      pixels.push_back(cv::Point(p.x, p.y));
+      ARCloud::Ptr selected_points = ata::filterCloud(cloud, pixels);
 
-	  //Use the kinect data to find a plane and pose for the marker
-	  int ret = PlaneFitPoseImprovement(i, m->ros_corners_3D, selected_points, cloud, m->pose);
-	}
+      //Use the kinect data to find a plane and pose for the marker
+      int ret = PlaneFitPoseImprovement(i, m->ros_corners_3D, selected_points, cloud, m->pose);
     }
+  }
 }
 
 
@@ -368,103 +368,102 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 
     try{
 
-
       arPoseMarkers_.markers.clear ();
       for (size_t i=0; i<marker_detector.markers->size(); i++)
-	{
-	  //Get the pose relative to the camera
-	  int id = (*(marker_detector.markers))[i].GetId();
-	  Pose p = (*(marker_detector.markers))[i].pose;
+      {
+        //Get the pose relative to the camera
+        int id = (*(marker_detector.markers))[i].GetId();
+        Pose p = (*(marker_detector.markers))[i].pose;
 
-	  double px = p.translation[0]/100.0;
-	  double py = p.translation[1]/100.0;
-	  double pz = p.translation[2]/100.0;
-	  double qx = p.quaternion[1];
-	  double qy = p.quaternion[2];
-	  double qz = p.quaternion[3];
-	  double qw = p.quaternion[0];
+        double px = p.translation[0]/100.0;
+        double py = p.translation[1]/100.0;
+        double pz = p.translation[2]/100.0;
+        double qx = p.quaternion[1];
+        double qy = p.quaternion[2];
+        double qz = p.quaternion[3];
+        double qw = p.quaternion[0];
 
-      tf::Quaternion rotation (qx,qy,qz,qw);
-      tf::Vector3 origin (px,py,pz);
-      tf::Transform t (rotation, origin);
-      tf::Vector3 markerOrigin (0, 0, 0);
-      tf::Transform m (tf::Quaternion::getIdentity (), markerOrigin);
-      tf::Transform markerPose = t * m; // marker pose in the camera frame
+        tf::Quaternion rotation (qx,qy,qz,qw);
+        tf::Vector3 origin (px,py,pz);
+        tf::Transform t (rotation, origin);
+        tf::Vector3 markerOrigin (0, 0, 0);
+        tf::Transform m (tf::Quaternion::getIdentity (), markerOrigin);
+        tf::Transform markerPose = t * m; // marker pose in the camera frame
 
-	  //Publish the transform from the camera to the marker
-	  std::string markerFrame = "ar_marker_";
-	  std::stringstream out;
-	  out << id;
-	  std::string id_string = out.str();
-	  markerFrame += id_string;
-	  tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
-	  tf_broadcaster->sendTransform(camToMarker);
+        //Publish the transform from the camera to the marker
+        std::string markerFrame = "ar_marker_";
+        std::stringstream out;
+        out << id;
+        std::string id_string = out.str();
+        markerFrame += id_string;
+        tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
+        tf_broadcaster->sendTransform(camToMarker);
 
-	  //Create the rviz visualization messages
-	  tf::poseTFToMsg (markerPose, rvizMarker_.pose);
-	  rvizMarker_.header.frame_id = image_msg->header.frame_id;
-	  rvizMarker_.header.stamp = image_msg->header.stamp;
-	  rvizMarker_.id = id;
+        //Create the rviz visualization messages
+        tf::poseTFToMsg (markerPose, rvizMarker_.pose);
+        rvizMarker_.header.frame_id = image_msg->header.frame_id;
+        rvizMarker_.header.stamp = image_msg->header.stamp;
+        rvizMarker_.id = id;
 
-	  rvizMarker_.scale.x = 1.0 * marker_size/100.0;
-	  rvizMarker_.scale.y = 1.0 * marker_size/100.0;
-	  rvizMarker_.scale.z = 0.2 * marker_size/100.0;
-	  rvizMarker_.ns = "basic_shapes";
-	  rvizMarker_.type = visualization_msgs::Marker::CUBE;
-	  rvizMarker_.action = visualization_msgs::Marker::ADD;
-	  switch (id)
-	    {
-	    case 0:
-	      rvizMarker_.color.r = 0.0f;
-	      rvizMarker_.color.g = 0.0f;
-	      rvizMarker_.color.b = 1.0f;
-	      rvizMarker_.color.a = 1.0;
-	      break;
-	    case 1:
-	      rvizMarker_.color.r = 1.0f;
-	      rvizMarker_.color.g = 0.0f;
-	      rvizMarker_.color.b = 0.0f;
-	      rvizMarker_.color.a = 1.0;
-	      break;
-	    case 2:
-	      rvizMarker_.color.r = 0.0f;
-	      rvizMarker_.color.g = 1.0f;
-	      rvizMarker_.color.b = 0.0f;
-	      rvizMarker_.color.a = 1.0;
-	      break;
-	    case 3:
-	      rvizMarker_.color.r = 0.0f;
-	      rvizMarker_.color.g = 0.5f;
-	      rvizMarker_.color.b = 0.5f;
-	      rvizMarker_.color.a = 1.0;
-	      break;
-	    case 4:
-	      rvizMarker_.color.r = 0.5f;
-	      rvizMarker_.color.g = 0.5f;
-	      rvizMarker_.color.b = 0.0;
-	      rvizMarker_.color.a = 1.0;
-	      break;
-	    default:
-	      rvizMarker_.color.r = 0.5f;
-	      rvizMarker_.color.g = 0.0f;
-	      rvizMarker_.color.b = 0.5f;
-	      rvizMarker_.color.a = 1.0;
-	      break;
-	    }
-	  rvizMarker_.lifetime = ros::Duration (1.0);
-	  rvizMarkerPub_.publish (rvizMarker_);
+        rvizMarker_.scale.x = 1.0 * marker_size/100.0;
+        rvizMarker_.scale.y = 1.0 * marker_size/100.0;
+        rvizMarker_.scale.z = 0.2 * marker_size/100.0;
+        rvizMarker_.ns = "basic_shapes";
+        rvizMarker_.type = visualization_msgs::Marker::CUBE;
+        rvizMarker_.action = visualization_msgs::Marker::ADD;
+        switch (id)
+        {
+          case 0:
+            rvizMarker_.color.r = 0.0f;
+            rvizMarker_.color.g = 0.0f;
+            rvizMarker_.color.b = 1.0f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 1:
+            rvizMarker_.color.r = 1.0f;
+            rvizMarker_.color.g = 0.0f;
+            rvizMarker_.color.b = 0.0f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 2:
+            rvizMarker_.color.r = 0.0f;
+            rvizMarker_.color.g = 1.0f;
+            rvizMarker_.color.b = 0.0f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 3:
+            rvizMarker_.color.r = 0.0f;
+            rvizMarker_.color.g = 0.5f;
+            rvizMarker_.color.b = 0.5f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 4:
+            rvizMarker_.color.r = 0.5f;
+            rvizMarker_.color.g = 0.5f;
+            rvizMarker_.color.b = 0.0;
+            rvizMarker_.color.a = 1.0;
+            break;
+          default:
+            rvizMarker_.color.r = 0.5f;
+            rvizMarker_.color.g = 0.0f;
+            rvizMarker_.color.b = 0.5f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          }
+        rvizMarker_.lifetime = ros::Duration (1.0);
+        rvizMarkerPub_.publish (rvizMarker_);
 
-	  //Get the pose of the tag in the camera frame, then the output frame (usually torso)
-	  tf::Transform tagPoseOutput = CamToOutput * markerPose;
+        //Get the pose of the tag in the camera frame, then the output frame (usually torso)
+        tf::Transform tagPoseOutput = CamToOutput * markerPose;
 
-	  //Create the pose marker messages
-	  ar_track_alvar_msgs::AlvarMarker ar_pose_marker;
-	  tf::poseTFToMsg (tagPoseOutput, ar_pose_marker.pose.pose);
-	  ar_pose_marker.header.frame_id = output_frame;
-	  ar_pose_marker.header.stamp = image_msg->header.stamp;
-	  ar_pose_marker.id = id;
-	  arPoseMarkers_.markers.push_back (ar_pose_marker);
-	}
+        //Create the pose marker messages
+        ar_track_alvar_msgs::AlvarMarker ar_pose_marker;
+        tf::poseTFToMsg (tagPoseOutput, ar_pose_marker.pose.pose);
+        ar_pose_marker.header.frame_id = output_frame;
+        ar_pose_marker.header.stamp = image_msg->header.stamp;
+        ar_pose_marker.id = id;
+        arPoseMarkers_.markers.push_back (ar_pose_marker);
+      }
       arPoseMarkers_.header.stamp = image_msg->header.stamp;
       arMarkerPub_.publish (arPoseMarkers_);
     }

--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -83,8 +83,10 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 {
     //If we've already gotten the cam info, then go ahead
   if (cam->getCamInfo_){
-    if (output_frame_from_msg)
+    if (output_frame_from_msg) {
       output_frame = cam->frame;
+      output_frame_from_msg = false;
+    }
     try{
       tf::StampedTransform CamToOutput;
       try{

--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -65,6 +65,7 @@ MarkerDetector<MarkerData> marker_detector;
 
 bool enableSwitched = false;
 bool enabled = true;
+bool output_frame_from_msg;
 double max_frequency;
 double marker_size;
 double max_new_marker_error;
@@ -81,138 +82,141 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg);
 void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 {
     //If we've already gotten the cam info, then go ahead
-	if(cam->getCamInfo_){
-		try{
-			tf::StampedTransform CamToOutput;
-    			try{
-					tf_listener->waitForTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, ros::Duration(1.0));
-					tf_listener->lookupTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, CamToOutput);
-   				}
-    			catch (tf::TransformException ex){
-      				ROS_ERROR("%s",ex.what());
-    			}
+  if (cam->getCamInfo_){
+    if (output_frame_from_msg)
+      output_frame = cam->frame;
+    try{
+      tf::StampedTransform CamToOutput;
+      try{
+        tf_listener->waitForTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, ros::Duration(1.0));
+        tf_listener->lookupTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, CamToOutput);
+      }
+      catch (tf::TransformException ex){
+        ROS_ERROR("%s",ex.what());
+      }
 
 
-            //Convert the image
-            cv_ptr_ = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::BGR8);
+      //Convert the image
+      cv_ptr_ = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::BGR8);
 
-            //Get the estimated pose of the main markers by using all the markers in each bundle
+      //Get the estimated pose of the main markers by using all the markers in each bundle
 
-            // GetMultiMarkersPoses expects an IplImage*, but as of ros groovy, cv_bridge gives
-            // us a cv::Mat. I'm too lazy to change to cv::Mat throughout right now, so I
-            // do this conversion here -jbinney
-            IplImage ipl_image = cv_ptr_->image;
+      // GetMultiMarkersPoses expects an IplImage*, but as of ros groovy, cv_bridge gives
+      // us a cv::Mat. I'm too lazy to change to cv::Mat throughout right now, so I
+      // do this conversion here -jbinney
+      IplImage ipl_image = cv_ptr_->image;
 
-            marker_detector.Detect(&ipl_image, cam, true, false, max_new_marker_error, max_track_error, CVSEQ, true);
-            arPoseMarkers_.markers.clear ();
-			for (size_t i=0; i<marker_detector.markers->size(); i++)
-			{
-				//Get the pose relative to the camera
-        		int id = (*(marker_detector.markers))[i].GetId();
-				Pose p = (*(marker_detector.markers))[i].pose;
-				double px = p.translation[0]/100.0;
-				double py = p.translation[1]/100.0;
-				double pz = p.translation[2]/100.0;
-				double qx = p.quaternion[1];
-				double qy = p.quaternion[2];
-				double qz = p.quaternion[3];
-				double qw = p.quaternion[0];
+      marker_detector.Detect(&ipl_image, cam, true, false, max_new_marker_error, max_track_error, CVSEQ, true);
+      arPoseMarkers_.markers.clear ();
 
-                tf::Quaternion rotation (qx,qy,qz,qw);
-                tf::Vector3 origin (px,py,pz);
-                tf::Transform t (rotation, origin);
-                tf::Vector3 markerOrigin (0, 0, 0);
-                tf::Transform m (tf::Quaternion::getIdentity (), markerOrigin);
-                tf::Transform markerPose = t * m; // marker pose in the camera frame
+      for (size_t i=0; i<marker_detector.markers->size(); i++)
+      {
+        //Get the pose relative to the camera
+        int id = (*(marker_detector.markers))[i].GetId();
+        Pose p = (*(marker_detector.markers))[i].pose;
+        double px = p.translation[0]/100.0;
+        double py = p.translation[1]/100.0;
+        double pz = p.translation[2]/100.0;
+        double qx = p.quaternion[1];
+        double qy = p.quaternion[2];
+        double qz = p.quaternion[3];
+        double qw = p.quaternion[0];
 
-                tf::Vector3 z_axis_cam = tf::Transform(rotation, tf::Vector3(0,0,0)) * tf::Vector3(0, 0, 1);
-//                ROS_INFO("%02i Z in cam frame: %f %f %f",id, z_axis_cam.x(), z_axis_cam.y(), z_axis_cam.z());
-                /// as we can't see through markers, this one is false positive detection
-                if (z_axis_cam.z() > 0)
-                {
-                    continue;
-                }
+        tf::Quaternion rotation (qx,qy,qz,qw);
+        tf::Vector3 origin (px,py,pz);
+        tf::Transform t (rotation, origin);
+        tf::Vector3 markerOrigin (0, 0, 0);
+        tf::Transform m (tf::Quaternion::getIdentity (), markerOrigin);
+        tf::Transform markerPose = t * m; // marker pose in the camera frame
 
-				//Publish the transform from the camera to the marker
-				std::string markerFrame = "ar_marker_";
-				std::stringstream out;
-				out << id;
-				std::string id_string = out.str();
-				markerFrame += id_string;
-				tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
-    			tf_broadcaster->sendTransform(camToMarker);
+        tf::Vector3 z_axis_cam = tf::Transform(rotation, tf::Vector3(0,0,0)) * tf::Vector3(0, 0, 1);
+        // ROS_INFO("%02i Z in cam frame: %f %f %f",id, z_axis_cam.x(), z_axis_cam.y(), z_axis_cam.z());
+        // as we can't see through markers, this one is false positive detection
+        if (z_axis_cam.z() > 0)
+        {
+          continue;
+        }
 
-				//Create the rviz visualization messages
-				tf::poseTFToMsg (markerPose, rvizMarker_.pose);
-				rvizMarker_.header.frame_id = image_msg->header.frame_id;
-				rvizMarker_.header.stamp = image_msg->header.stamp;
-				rvizMarker_.id = id;
+        //Publish the transform from the camera to the marker
+        std::string markerFrame = "ar_marker_";
+        std::stringstream out;
+        out << id;
+        std::string id_string = out.str();
+        markerFrame += id_string;
+        tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
+        tf_broadcaster->sendTransform(camToMarker);
 
-				rvizMarker_.scale.x = 1.0 * marker_size/100.0;
-				rvizMarker_.scale.y = 1.0 * marker_size/100.0;
-				rvizMarker_.scale.z = 0.2 * marker_size/100.0;
-				rvizMarker_.ns = "basic_shapes";
-				rvizMarker_.type = visualization_msgs::Marker::CUBE;
-				rvizMarker_.action = visualization_msgs::Marker::ADD;
-				switch (id)
-				{
-				  case 0:
-				    rvizMarker_.color.r = 0.0f;
-				    rvizMarker_.color.g = 0.0f;
-				    rvizMarker_.color.b = 1.0f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 1:
-				    rvizMarker_.color.r = 1.0f;
-				    rvizMarker_.color.g = 0.0f;
-				    rvizMarker_.color.b = 0.0f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 2:
-				    rvizMarker_.color.r = 0.0f;
-				    rvizMarker_.color.g = 1.0f;
-				    rvizMarker_.color.b = 0.0f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 3:
-				    rvizMarker_.color.r = 0.0f;
-				    rvizMarker_.color.g = 0.5f;
-				    rvizMarker_.color.b = 0.5f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 4:
-				    rvizMarker_.color.r = 0.5f;
-				    rvizMarker_.color.g = 0.5f;
-				    rvizMarker_.color.b = 0.0;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  default:
-				    rvizMarker_.color.r = 0.5f;
-				    rvizMarker_.color.g = 0.0f;
-				    rvizMarker_.color.b = 0.5f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				}
-				rvizMarker_.lifetime = ros::Duration (1.0);
-				rvizMarkerPub_.publish (rvizMarker_);
+        //Create the rviz visualization messages
+        tf::poseTFToMsg (markerPose, rvizMarker_.pose);
+        rvizMarker_.header.frame_id = image_msg->header.frame_id;
+        rvizMarker_.header.stamp = image_msg->header.stamp;
+        rvizMarker_.id = id;
 
-				//Get the pose of the tag in the camera frame, then the output frame (usually torso)
-				tf::Transform tagPoseOutput = CamToOutput * markerPose;
+        rvizMarker_.scale.x = 1.0 * marker_size/100.0;
+        rvizMarker_.scale.y = 1.0 * marker_size/100.0;
+        rvizMarker_.scale.z = 0.2 * marker_size/100.0;
+        rvizMarker_.ns = "basic_shapes";
+        rvizMarker_.type = visualization_msgs::Marker::CUBE;
+        rvizMarker_.action = visualization_msgs::Marker::ADD;
+        switch (id)
+        {
+          case 0:
+            rvizMarker_.color.r = 0.0f;
+            rvizMarker_.color.g = 0.0f;
+            rvizMarker_.color.b = 1.0f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 1:
+            rvizMarker_.color.r = 1.0f;
+            rvizMarker_.color.g = 0.0f;
+            rvizMarker_.color.b = 0.0f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 2:
+            rvizMarker_.color.r = 0.0f;
+            rvizMarker_.color.g = 1.0f;
+            rvizMarker_.color.b = 0.0f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 3:
+            rvizMarker_.color.r = 0.0f;
+            rvizMarker_.color.g = 0.5f;
+            rvizMarker_.color.b = 0.5f;
+            rvizMarker_.color.a = 1.0;
+            break;
+          case 4:
+            rvizMarker_.color.r = 0.5f;
+            rvizMarker_.color.g = 0.5f;
+            rvizMarker_.color.b = 0.0;
+            rvizMarker_.color.a = 1.0;
+            break;
+          default:
+            rvizMarker_.color.r = 0.5f;
+            rvizMarker_.color.g = 0.0f;
+            rvizMarker_.color.b = 0.5f;
+            rvizMarker_.color.a = 1.0;
+            break;
+        }
+        rvizMarker_.lifetime = ros::Duration (1.0);
+        rvizMarkerPub_.publish (rvizMarker_);
 
-				//Create the pose marker messages
-				ar_track_alvar_msgs::AlvarMarker ar_pose_marker;
-				tf::poseTFToMsg (tagPoseOutput, ar_pose_marker.pose.pose);
-      			ar_pose_marker.header.frame_id = output_frame;
-			    ar_pose_marker.header.stamp = image_msg->header.stamp;
-			    ar_pose_marker.id = id;
-			    arPoseMarkers_.markers.push_back (ar_pose_marker);
-			}
-			arMarkerPub_.publish (arPoseMarkers_);
-		}
-        catch (cv_bridge::Exception& e){
-      		ROS_ERROR ("Could not convert from '%s' to 'rgb8'.", image_msg->encoding.c_str ());
-    	}
-	}
+        //Get the pose of the tag in the camera frame, then the output frame (usually torso)
+        tf::Transform tagPoseOutput = CamToOutput * markerPose;
+
+        //Create the pose marker messages
+        ar_track_alvar_msgs::AlvarMarker ar_pose_marker;
+        tf::poseTFToMsg (tagPoseOutput, ar_pose_marker.pose.pose);
+        ar_pose_marker.header.frame_id = output_frame;
+        ar_pose_marker.header.stamp = image_msg->header.stamp;
+        ar_pose_marker.id = id;
+        arPoseMarkers_.markers.push_back (ar_pose_marker);
+      }
+      arMarkerPub_.publish (arPoseMarkers_);
+    }
+    catch (cv_bridge::Exception& e){
+      ROS_ERROR ("Could not convert from '%s' to 'rgb8'.", image_msg->encoding.c_str ());
+    }
+  }
 }
 
 void configCallback(ar_track_alvar::ParamsConfig &config, uint32_t level)
@@ -231,14 +235,14 @@ void configCallback(ar_track_alvar::ParamsConfig &config, uint32_t level)
 
 void enableCallback(const std_msgs::BoolConstPtr& msg)
 {
-    enableSwitched = enabled != msg->data;
-    enabled = msg->data;
+  enableSwitched = enabled != msg->data;
+  enabled = msg->data;
 }
 
 int main(int argc, char *argv[])
 {
-	ros::init (argc, argv, "marker_detect");
-	ros::NodeHandle n, pn("~");
+  ros::init (argc, argv, "marker_detect");
+  ros::NodeHandle n, pn("~");
 
   if(argc > 1) {
     ROS_WARN("Command line arguments are deprecated. Consider using ROS parameters and remappings.");
@@ -278,8 +282,11 @@ int main(int argc, char *argv[])
     pn.setParam("max_frequency", max_frequency);  // in case it was not set.
     pn.param("marker_resolution", marker_resolution, 5);
     pn.param("marker_margin", marker_margin, 2);
-    if (!pn.getParam("output_frame", output_frame)) {
-      ROS_ERROR("Param 'output_frame' has to be set.");
+    pn.param("output_frame_from_msg", output_frame_from_msg, false);
+
+    if (!output_frame_from_msg && !pn.getParam("output_frame", output_frame)) {
+      ROS_ERROR("Param 'output_frame' has to be set if the output frame is not "
+                "derived from the point cloud message.");
       exit(EXIT_FAILURE);
     }
 
@@ -293,13 +300,13 @@ int main(int argc, char *argv[])
   pn.setParam("max_new_marker_error", max_new_marker_error);
   pn.setParam("max_track_error", max_track_error);
 
-	marker_detector.SetMarkerSize(marker_size, marker_resolution, marker_margin);
+  marker_detector.SetMarkerSize(marker_size, marker_resolution, marker_margin);
 
-	cam = new Camera(n, cam_info_topic);
-	tf_listener = new tf::TransformListener(n);
-	tf_broadcaster = new tf::TransformBroadcaster();
-	arMarkerPub_ = n.advertise < ar_track_alvar_msgs::AlvarMarkers > ("ar_pose_marker", 0);
-	rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
+  cam = new Camera(n, cam_info_topic);
+  tf_listener = new tf::TransformListener(n);
+  tf_broadcaster = new tf::TransformBroadcaster();
+  arMarkerPub_ = n.advertise < ar_track_alvar_msgs::AlvarMarkers > ("ar_pose_marker", 0);
+  rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
 
   // Prepare dynamic reconfiguration
   dynamic_reconfigure::Server < ar_track_alvar::ParamsConfig > server;
@@ -308,12 +315,12 @@ int main(int argc, char *argv[])
   f = boost::bind(&configCallback, _1, _2);
   server.setCallback(f);
 
-	//Give tf a chance to catch up before the camera callback starts asking for transforms
+  //Give tf a chance to catch up before the camera callback starts asking for transforms
   // It will also reconfigure parameters for the first time, setting the default values
-	ros::Duration(1.0).sleep();
-	ros::spinOnce();
+  ros::Duration(1.0).sleep();
+  ros::spinOnce();
 
-	image_transport::ImageTransport it_(n);
+  image_transport::ImageTransport it_(n);
 
   // Run at the configured rate, discarding pointcloud msgs if necessary
   ros::Rate rate(max_frequency);
@@ -339,13 +346,13 @@ int main(int argc, char *argv[])
     {
       // Enable/disable switch: subscribe/unsubscribe to make use of pointcloud processing nodelet
       // lazy publishing policy; in CPU-scarce computer as TurtleBot's laptop this is a huge saving
-        if (enabled)
-            cam_sub_ = it_.subscribe(cam_image_topic, 1, &getCapCallback);
-        else
-            cam_sub_.shutdown();
-        enableSwitched = false;
+      if (enabled)
+        cam_sub_ = it_.subscribe(cam_image_topic, 1, &getCapCallback);
+      else
+        cam_sub_.shutdown();
+      enableSwitched = false;
     }
   }
 
-    return 0;
+  return 0;
 }

--- a/ar_track_alvar/src/Camera.cpp
+++ b/ar_track_alvar/src/Camera.cpp
@@ -229,6 +229,8 @@ void Camera::SetCameraInfo(const sensor_msgs::CameraInfo &camInfo)
 {
     cam_info_ = camInfo;
 
+    frame = cam_info_.header.frame_id;
+
     calib_x_res = cam_info_.width;
     calib_y_res = cam_info_.height;
     x_res = calib_x_res;


### PR DESCRIPTION
Hi there!

I jut added a output_frame_from_msg parameter to the IndividualMarkersNoKinect node, to parallel the parameter of the same name in the kinect-enabled node. It pulls the output frame from the camera info topic.

Also took the liberty of:
- setting output_frame_from_msg to false after the output frame is set to prevent redundant string copies (both nodes)
- fixing indentation inconsistencies for the files I touched (2 spaces)