### PR TITLE
Fix invalid transform use

### DIFF
--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -90,6 +90,7 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
             }
             catch (tf::TransformException ex){
                 ROS_ERROR("%s",ex.what());
+                return;
             }
 
 

--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -81,16 +81,16 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg);
 void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 {
     //If we've already gotten the cam info, then go ahead
-	if(cam->getCamInfo_){
-		try{
-			tf::StampedTransform CamToOutput;
-    			try{
-					tf_listener->waitForTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, ros::Duration(1.0));
-					tf_listener->lookupTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, CamToOutput);
-   				}
-    			catch (tf::TransformException ex){
-      				ROS_ERROR("%s",ex.what());
-    			}
+    if(cam->getCamInfo_){
+        try{
+            tf::StampedTransform CamToOutput;
+            try{
+                tf_listener->waitForTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, ros::Duration(1.0));
+                tf_listener->lookupTransform(output_frame, image_msg->header.frame_id, image_msg->header.stamp, CamToOutput);
+            }
+            catch (tf::TransformException ex){
+                ROS_ERROR("%s",ex.what());
+            }
 
 
             //Convert the image
@@ -105,18 +105,18 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 
             marker_detector.Detect(&ipl_image, cam, true, false, max_new_marker_error, max_track_error, CVSEQ, true);
             arPoseMarkers_.markers.clear ();
-			for (size_t i=0; i<marker_detector.markers->size(); i++)
-			{
-				//Get the pose relative to the camera
-        		int id = (*(marker_detector.markers))[i].GetId();
-				Pose p = (*(marker_detector.markers))[i].pose;
-				double px = p.translation[0]/100.0;
-				double py = p.translation[1]/100.0;
-				double pz = p.translation[2]/100.0;
-				double qx = p.quaternion[1];
-				double qy = p.quaternion[2];
-				double qz = p.quaternion[3];
-				double qw = p.quaternion[0];
+            for (size_t i=0; i<marker_detector.markers->size(); i++)
+            {
+                //Get the pose relative to the camera
+                int id = (*(marker_detector.markers))[i].GetId();
+                Pose p = (*(marker_detector.markers))[i].pose;
+                double px = p.translation[0]/100.0;
+                double py = p.translation[1]/100.0;
+                double pz = p.translation[2]/100.0;
+                double qx = p.quaternion[1];
+                double qy = p.quaternion[2];
+                double qz = p.quaternion[3];
+                double qw = p.quaternion[0];
 
                 tf::Quaternion rotation (qx,qy,qz,qw);
                 tf::Vector3 origin (px,py,pz);
@@ -133,86 +133,86 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
                     continue;
                 }
 
-				//Publish the transform from the camera to the marker
-				std::string markerFrame = "ar_marker_";
-				std::stringstream out;
-				out << id;
-				std::string id_string = out.str();
-				markerFrame += id_string;
-				tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
-    			tf_broadcaster->sendTransform(camToMarker);
+                //Publish the transform from the camera to the marker
+                std::string markerFrame = "ar_marker_";
+                std::stringstream out;
+                out << id;
+                std::string id_string = out.str();
+                markerFrame += id_string;
+                tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
+                tf_broadcaster->sendTransform(camToMarker);
 
-				//Create the rviz visualization messages
-				tf::poseTFToMsg (markerPose, rvizMarker_.pose);
-				rvizMarker_.header.frame_id = image_msg->header.frame_id;
-				rvizMarker_.header.stamp = image_msg->header.stamp;
-				rvizMarker_.id = id;
+                //Create the rviz visualization messages
+                tf::poseTFToMsg (markerPose, rvizMarker_.pose);
+                rvizMarker_.header.frame_id = image_msg->header.frame_id;
+                rvizMarker_.header.stamp = image_msg->header.stamp;
+                rvizMarker_.id = id;
 
-				rvizMarker_.scale.x = 1.0 * marker_size/100.0;
-				rvizMarker_.scale.y = 1.0 * marker_size/100.0;
-				rvizMarker_.scale.z = 0.2 * marker_size/100.0;
-				rvizMarker_.ns = "basic_shapes";
-				rvizMarker_.type = visualization_msgs::Marker::CUBE;
-				rvizMarker_.action = visualization_msgs::Marker::ADD;
-				switch (id)
-				{
-				  case 0:
-				    rvizMarker_.color.r = 0.0f;
-				    rvizMarker_.color.g = 0.0f;
-				    rvizMarker_.color.b = 1.0f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 1:
-				    rvizMarker_.color.r = 1.0f;
-				    rvizMarker_.color.g = 0.0f;
-				    rvizMarker_.color.b = 0.0f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 2:
-				    rvizMarker_.color.r = 0.0f;
-				    rvizMarker_.color.g = 1.0f;
-				    rvizMarker_.color.b = 0.0f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 3:
-				    rvizMarker_.color.r = 0.0f;
-				    rvizMarker_.color.g = 0.5f;
-				    rvizMarker_.color.b = 0.5f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  case 4:
-				    rvizMarker_.color.r = 0.5f;
-				    rvizMarker_.color.g = 0.5f;
-				    rvizMarker_.color.b = 0.0;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				  default:
-				    rvizMarker_.color.r = 0.5f;
-				    rvizMarker_.color.g = 0.0f;
-				    rvizMarker_.color.b = 0.5f;
-				    rvizMarker_.color.a = 1.0;
-				    break;
-				}
-				rvizMarker_.lifetime = ros::Duration (1.0);
-				rvizMarkerPub_.publish (rvizMarker_);
+                rvizMarker_.scale.x = 1.0 * marker_size/100.0;
+                rvizMarker_.scale.y = 1.0 * marker_size/100.0;
+                rvizMarker_.scale.z = 0.2 * marker_size/100.0;
+                rvizMarker_.ns = "basic_shapes";
+                rvizMarker_.type = visualization_msgs::Marker::CUBE;
+                rvizMarker_.action = visualization_msgs::Marker::ADD;
+                switch (id)
+                {
+                  case 0:
+                    rvizMarker_.color.r = 0.0f;
+                    rvizMarker_.color.g = 0.0f;
+                    rvizMarker_.color.b = 1.0f;
+                    rvizMarker_.color.a = 1.0;
+                    break;
+                  case 1:
+                    rvizMarker_.color.r = 1.0f;
+                    rvizMarker_.color.g = 0.0f;
+                    rvizMarker_.color.b = 0.0f;
+                    rvizMarker_.color.a = 1.0;
+                    break;
+                  case 2:
+                    rvizMarker_.color.r = 0.0f;
+                    rvizMarker_.color.g = 1.0f;
+                    rvizMarker_.color.b = 0.0f;
+                    rvizMarker_.color.a = 1.0;
+                    break;
+                  case 3:
+                    rvizMarker_.color.r = 0.0f;
+                    rvizMarker_.color.g = 0.5f;
+                    rvizMarker_.color.b = 0.5f;
+                    rvizMarker_.color.a = 1.0;
+                    break;
+                  case 4:
+                    rvizMarker_.color.r = 0.5f;
+                    rvizMarker_.color.g = 0.5f;
+                    rvizMarker_.color.b = 0.0;
+                    rvizMarker_.color.a = 1.0;
+                    break;
+                  default:
+                    rvizMarker_.color.r = 0.5f;
+                    rvizMarker_.color.g = 0.0f;
+                    rvizMarker_.color.b = 0.5f;
+                    rvizMarker_.color.a = 1.0;
+                    break;
+                }
+                rvizMarker_.lifetime = ros::Duration (1.0);
+                rvizMarkerPub_.publish (rvizMarker_);
 
-				//Get the pose of the tag in the camera frame, then the output frame (usually torso)
-				tf::Transform tagPoseOutput = CamToOutput * markerPose;
+                //Get the pose of the tag in the camera frame, then the output frame (usually torso)
+                tf::Transform tagPoseOutput = CamToOutput * markerPose;
 
-				//Create the pose marker messages
-				ar_track_alvar_msgs::AlvarMarker ar_pose_marker;
-				tf::poseTFToMsg (tagPoseOutput, ar_pose_marker.pose.pose);
-      			ar_pose_marker.header.frame_id = output_frame;
-			    ar_pose_marker.header.stamp = image_msg->header.stamp;
-			    ar_pose_marker.id = id;
-			    arPoseMarkers_.markers.push_back (ar_pose_marker);
-			}
-			arMarkerPub_.publish (arPoseMarkers_);
-		}
+                //Create the pose marker messages
+                ar_track_alvar_msgs::AlvarMarker ar_pose_marker;
+                tf::poseTFToMsg (tagPoseOutput, ar_pose_marker.pose.pose);
+                ar_pose_marker.header.frame_id = output_frame;
+                ar_pose_marker.header.stamp = image_msg->header.stamp;
+                ar_pose_marker.id = id;
+                arPoseMarkers_.markers.push_back (ar_pose_marker);
+            }
+            arMarkerPub_.publish (arPoseMarkers_);
+        }
         catch (cv_bridge::Exception& e){
-      		ROS_ERROR ("Could not convert from '%s' to 'rgb8'.", image_msg->encoding.c_str ());
-    	}
-	}
+              ROS_ERROR ("Could not convert from '%s' to 'rgb8'.", image_msg->encoding.c_str ());
+        }
+    }
 }
 
 void configCallback(ar_track_alvar::ParamsConfig &config, uint32_t level)
@@ -237,8 +237,8 @@ void enableCallback(const std_msgs::BoolConstPtr& msg)
 
 int main(int argc, char *argv[])
 {
-	ros::init (argc, argv, "marker_detect");
-	ros::NodeHandle n, pn("~");
+  ros::init (argc, argv, "marker_detect");
+  ros::NodeHandle n, pn("~");
 
   if(argc > 1) {
     ROS_WARN("Command line arguments are deprecated. Consider using ROS parameters and remappings.");
@@ -293,13 +293,13 @@ int main(int argc, char *argv[])
   pn.setParam("max_new_marker_error", max_new_marker_error);
   pn.setParam("max_track_error", max_track_error);
 
-	marker_detector.SetMarkerSize(marker_size, marker_resolution, marker_margin);
+  marker_detector.SetMarkerSize(marker_size, marker_resolution, marker_margin);
 
-	cam = new Camera(n, cam_info_topic);
-	tf_listener = new tf::TransformListener(n);
-	tf_broadcaster = new tf::TransformBroadcaster();
-	arMarkerPub_ = n.advertise < ar_track_alvar_msgs::AlvarMarkers > ("ar_pose_marker", 0);
-	rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
+  cam = new Camera(n, cam_info_topic);
+  tf_listener = new tf::TransformListener(n);
+  tf_broadcaster = new tf::TransformBroadcaster();
+  arMarkerPub_ = n.advertise < ar_track_alvar_msgs::AlvarMarkers > ("ar_pose_marker", 0);
+  rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
 
   // Prepare dynamic reconfiguration
   dynamic_reconfigure::Server < ar_track_alvar::ParamsConfig > server;
@@ -308,12 +308,12 @@ int main(int argc, char *argv[])
   f = boost::bind(&configCallback, _1, _2);
   server.setCallback(f);
 
-	//Give tf a chance to catch up before the camera callback starts asking for transforms
+  //Give tf a chance to catch up before the camera callback starts asking for transforms
   // It will also reconfigure parameters for the first time, setting the default values
-	ros::Duration(1.0).sleep();
-	ros::spinOnce();
+  ros::Duration(1.0).sleep();
+  ros::spinOnce();
 
-	image_transport::ImageTransport it_(n);
+  image_transport::ImageTransport it_(n);
 
   // Run at the configured rate, discarding pointcloud msgs if necessary
   ros::Rate rate(max_frequency);


### PR DESCRIPTION
When a transform lookup fails it doesn't make sense to continue to operate on the specific image data because the any calculation made using the transform will be invalid and possibly very far off. In the specific case that I investigated we were getting massive values in the pose that were causing math errors.